### PR TITLE
Safe navigation operator only works on nil. 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .live
 networks
+**/.sifnoded

--- a/rake/lib/sifchain/chainops/sifnode/common.rb
+++ b/rake/lib/sifchain/chainops/sifnode/common.rb
@@ -10,47 +10,47 @@ module Sifchain
           def kubeconfig(args)
             return if ENV['KUBECONFIG']
 
-            "--kubeconfig #{get_arg :kubeconfig}" if args&.key? :kubeconfig
+            "--kubeconfig #{get_arg :kubeconfig}" if args.is_a?(Rake::TaskArguments) && args.key?(:kubeconfig)
           end
 
           def namespace(args)
-            return args[:namespace] if args&.key? :namespace
+            return args[:namespace] if args.is_a?(Rake::TaskArguments) && args.key?(:namespace)
 
             DEFAULTS[:namespace]
           end
 
           def container(args)
-            return args[:container] if args&.key? :container
+            return args[:container] if args.is_a?(Rake::TaskArguments) && args.key?(:container)
 
             DEFAULTS[:container]
           end
 
           def chain_id(args)
-            return args[:chain_id] if args&.key? :chain_id
+            return args[:chain_id] if args.is_a?(Rake::TaskArguments) && args.key?(:chain_id)
 
             DEFAULTS[:chain_id]
           end
 
           def bind_ip_address(args)
-            return args[:bind_ip_address] if args&.key? :bind_ip_address
+            return args[:bind_ip_address] if args.is_a?(Rake::TaskArguments) && args.key?(:bind_ip_address)
 
             DEFAULTS[:bind_ip_address]
           end
 
           def gas_price(args)
-            return args[:gas_price] if args&.key? :gas_price
+            return args[:gas_price] if args.is_a?(Rake::TaskArguments) &&  args.key?(:gas_price)
 
             DEFAULTS[:gas_price]
           end
 
           def keyring_backend(args)
-            return args[:keyring_backend] if args&.key? :keyring_backend
+            return args[:keyring_backend] if args.is_a?(Rake::TaskArguments) && args.key?(:keyring_backend)
 
             DEFAULTS[:keyring_backend]
           end
 
           def node(args)
-            return args[:node] if args&.key? :node
+            return args[:node] if args.is_a?(Rake::TaskArguments) && args.key?(:node)
 
             DEFAULTS[:node]
           end


### PR DESCRIPTION
Fixes the case where a symbol is used in rake tasks where a map was expected. 